### PR TITLE
Add support for IonCube for php 71 and 72

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ Our own Docker setup.
 5. `$ docker-compose up -d nginx` (restarting container to sync all .conf files)
 
 ## Switching PHP-FPM versions
-1. Make sure all containers are down. (docker ps should give no results)
-2. Edit your .env file to the desired version. (currently supporting 7.1 and 5.6 directions on how to do that are in the example file)
-3. Rebuild the php-fpm container (docker-compose build php-fpm on commandline)
+1. Make sure all containers are down. (`$ docker ps` should give no results)
+2. Edit your .env file to the desired version. (currently supporting 7.2, 7.1 and 5.6. Directions on how to do that are in the example file)
+3. Rebuild the php-fpm container (`$ docker-compose build php-fpm` on commandline)
 4. Now you can use yadock as usual with the desired PHP version.
+
+## Using IonCube Loader
+IonCube Loader is used to decode protected PHP code.  
+Read more on [the ioncube loader website](https://www.ioncube.com/loaders.php).  
+
+1. Make sure all containers are down (`$ docker ps` should give no results)
+2. Change the `PHP_FPM_INSTALL_IONCUBE` setting to true
+3. Rebuild the php-fpm container (`$ docker-compose build php-fpm` on commandline)
+4. When the build is complete you can bring the containers up again like usual`
 
 ## Use ElasticSearch
 1. Run the ElasticSearch Container with the docker-compose up command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
         - INSTALL_INTL=${PHP_FPM_INSTALL_INTL}
         - INSTALL_LDAP=${PHP_FPM_INSTALL_LDAP}
         - INSTALL_SWOOLE=${PHP_FPM_INSTALL_SWOOLE}
+        - INSTALL_IONCUBE=${PHP_FPM_INSTALL_IONCUBE}
       dockerfile: "Dockerfile-${PHP_VERSION}"
     volumes_from:
       - applications

--- a/env-example
+++ b/env-example
@@ -67,6 +67,7 @@ PHP_FPM_INSTALL_INTL=false
 PHP_FPM_INSTALL_GHOSTSCRIPT=false
 PHP_FPM_INSTALL_LDAP=false
 PHP_FPM_INSTALL_SWOOLE=false
+PHP_FPM_INSTALL_IONCUBE=false
 
 ### NGINX ######################################################################
 

--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -192,6 +192,20 @@ RUN if [ ${INSTALL_LDAP} = true ]; then \
     docker-php-ext-install ldap \
 ;fi
 
+#####################################
+# IonCube:
+#####################################
+
+ARG INSTALL_IONCUBE=false
+RUN if [ ${INSTALL_IONCUBE} = true ]; then \
+cd /tmp \
+   	&& curl -o ioncube.tar.gz http://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
+    && tar -xvvzf ioncube.tar.gz \
+    && mv ioncube/ioncube_loader_lin_7.1.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ \
+    && echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/ioncube_loader_lin_7.1.so" > /usr/local/etc/php/conf.d/00_docker-php-ext-ioncube_loader_lin_7.1.ini \
+    && rm -Rf ioncube.tar.gz ioncube \
+;fi
+
 #
 #--------------------------------------------------------------------------
 # Final Touch

--- a/php-fpm/Dockerfile-72
+++ b/php-fpm/Dockerfile-72
@@ -192,6 +192,20 @@ RUN if [ ${INSTALL_LDAP} = true ]; then \
     docker-php-ext-install ldap \
 ;fi
 
+#####################################
+# IonCube:
+#####################################
+
+ARG INSTALL_IONCUBE=false
+RUN if [ ${INSTALL_IONCUBE} = true ]; then \
+cd /tmp \
+   	&& curl -o ioncube.tar.gz http://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
+    && tar -xvvzf ioncube.tar.gz \
+    && mv ioncube/ioncube_loader_lin_7.2.so /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ \
+    && echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/ioncube_loader_lin_7.2.so" > /usr/local/etc/php/conf.d/00_docker-php-ext-ioncube_loader_lin_7.2.ini \
+    && rm -Rf ioncube.tar.gz ioncube \
+;fi
+
 #
 #--------------------------------------------------------------------------
 # Final Touch


### PR DESCRIPTION
Added support for ionCube Loader. This is done for PHP Versions 7.1 and 7.2. PHP 5.6 hits its end-of-life at the end of this month so no use to support that.

